### PR TITLE
Fix header to be older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chatbot</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
@@ -29,11 +29,6 @@
     </button>
     
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -68,26 +68,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -848,14 +828,6 @@ details[open] .suggested-header::before {
     
     .chat-main {
         order: 1;
-    }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
     }
     
     .chat-messages {


### PR DESCRIPTION
Fixes #3

Removed the Course Materials Assistant header and related elements while preserving theme toggle functionality.

## Changes
- Removed main header section with "Course Materials Assistant" title
- Removed subtitle about asking questions
- Cleaned up related CSS styles
- Updated page title to "RAG Chatbot"
- Preserved theme toggle functionality

Generated with [Claude Code](https://claude.ai/code)